### PR TITLE
Remove test-unit dependency; use standard Ruby minitest instead

### DIFF
--- a/io-extra.gemspec
+++ b/io-extra.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
     STDERR.puts 'Not supported on this platform. Exiting.'
     exit(-1)
   end
-   
+
   spec.name       = 'io-extra'
   spec.version    = '1.2.8'
   spec.author     = 'Daniel J. Berger'
@@ -28,8 +28,6 @@ Gem::Specification.new do |spec|
   spec.rubyforge_project = 'shards'
   spec.required_ruby_version = '>= 1.8.6'
 
-  spec.add_development_dependency('test-unit', '>= 2.5.0')
-   
   spec.description = <<-EOF
     Adds the IO.closefrom, IO.fdwalk, IO.pread, IO.pread_ptr, IO.pwrite, and
     IO.writev singleton methods as well as the IO#directio, IO#directio? and


### PR DESCRIPTION
Remove the development dependency on the 'test-unit' gem; instead use 'minitest' which is part of the Ruby standard library.

Note that `assert_nothing_raised` is not needed because the test will be marked as
'error' if an exception is raised from the test.