### PR TITLE
Refactor for Ruby 2.5+

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,14 @@
+== 1.4.0 - ???
+* Replaced the C versions of IO.pread and IO.pwrite singleton methods with
+  pure Ruby wrappers since core Ruby has implemented instance method versions
+  since Ruby 2.5.
+* Removed the pread_ptr method, I don't think anyone was using it. Might get
+  added back if there are complaints.
+* Removed the DIRECT constant since that is now defined by core Ruby.
+* Moved the VERSION constant into the pure Ruby file.
+* Now requires Ruby 2.5 or later.
+
+
 == 1.3.0 - 19-Oct-2018
 * Now assumes Ruby 2.1 or later. This has no effect on the external API, but
   it does allow for lots of internal cleanup.

--- a/CHANGES
+++ b/CHANGES
@@ -7,7 +7,8 @@
 * Removed the DIRECT constant since that is now defined by core Ruby.
 * Moved the VERSION constant into the pure Ruby file.
 * Now requires Ruby 2.5 or later.
-
+* Added a LICENSE file as required by the Apache-2.0 license.
+* The 'io-extra' file is now the preferred way to require this library.
 
 == 1.3.0 - 19-Oct-2018
 * Now assumes Ruby 2.1 or later. This has no effect on the external API, but

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,6 +1,7 @@
+* CHANGES
+* LICENSE
 * MANIFEST
 * README
-* CHANGES
 * Rakefile
 * io-extra.gemspec
 * certs/djberg96_pub.pem

--- a/README
+++ b/README
@@ -11,7 +11,7 @@
   gem install io-extra
 
 = Synopsis
-  require 'io/extra' # or 'io-extra'
+  require 'io-extra' # Do not use 'io/extra'
 
   # Close all file descriptors from 3 up.
   IO.closefrom(3)
@@ -27,6 +27,10 @@
   IO.writev(fh.fileno, %w[a b c])
 
 = Developer's Notes
+  The "require 'io-extra'" is preferred over 'io/extra' because this is a mix
+  of pure Ruby and C extension. The former require's the latter, so that way
+  you get all the methods and constants that you expect.
+
   You might be wondering what the difference is between my implementation of
   IO.closefrom and a pure Ruby version that looks something like this:
 
@@ -73,10 +77,6 @@
   Please file any bug reports on the project page at
   https://github.com/djberg96/io-extra
 
-= Future Plans
-  * Switch from C extension to FFI (maybe).
-  * Add the IO.pselect method.
-
 = Acknowledgements
   Eric Wong for some great work on Linux compatibility and other fixes, as
   well as the code for the IO.writev method.
@@ -85,7 +85,7 @@
   Apache-2.0
 
 = Copyright
-  (C) 2003-2018 Daniel J. Berger
+  (C) 2003-2020 Daniel J. Berger
   All Rights Reserved
     
 = Warranty

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -10,8 +10,6 @@ have_header('sys/uio.h')
 have_func('closefrom')
 have_func('fdwalk')
 have_func('directio')
-have_func('pread')
-have_func('pwrite')
 have_func('writev')
 have_func('ttyname')
 

--- a/io-extra.gemspec
+++ b/io-extra.gemspec
@@ -40,8 +40,8 @@ Gem::Specification.new do |spec|
   }
    
   spec.description = <<-EOF
-    Adds the IO.closefrom, IO.fdwalk, IO.pread, IO.pread_ptr, IO.pwrite, and
-    IO.writev singleton methods as well as the IO#directio, IO#directio? and
-    IO#ttyname instance methods (for those platforms that support them).
+    Adds the IO.closefrom, IO.fdwalk, IO.pread, IO.pwrite, and IO.writev
+    singleton methods as well as the IO#directio, IO#directio? and IO#ttyname
+    instance methods (for those platforms that support them).
   EOF
 end

--- a/io-extra.gemspec
+++ b/io-extra.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   end
    
   spec.name       = 'io-extra'
-  spec.version    = '1.3.0'
+  spec.version    = '1.4.0'
   spec.author     = 'Daniel J. Berger'
   spec.license    = 'Apache-2.0'
   spec.email      = 'djberg96@gmail.com'
@@ -26,9 +26,9 @@ Gem::Specification.new do |spec|
     'ext/io/extra.c'
   ]
 
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
-  spec.add_development_dependency('test-unit', '>= 2.5.0')
+  spec.add_development_dependency('rspec', '~> 3.9')
 
   spec.metadata = {
     'homepage_uri'      => 'https://github.com/djberg96/io-extra',

--- a/io-extra.gemspec
+++ b/io-extra.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.5.0'
 
-  spec.add_development_dependency('rspec', '~> 3.9')
+  spec.add_development_dependency('test-unit', '~> 3.0')
 
   spec.metadata = {
     'homepage_uri'      => 'https://github.com/djberg96/io-extra',

--- a/lib/io-extra.rb
+++ b/lib/io-extra.rb
@@ -1,1 +1,15 @@
 require 'io/extra'
+
+class IO
+  # Singleton version of the IO#pwrite method.
+  #
+  def self.pwrite(fd, string, offset)
+    fd.pwrite(string, offset)
+  end
+
+  # Singleton version of the IO#pread method.
+  #
+  def self.pread(fd, maxlen, offset)
+    fd.pread(maxlen, offset)
+  end
+end

--- a/lib/io-extra.rb
+++ b/lib/io-extra.rb
@@ -1,6 +1,8 @@
 require 'io/extra'
 
 class IO
+  EXTRA_VERSION = '1.4.0'.freeze
+
   # Singleton version of the IO#pwrite method.
   #
   def self.pwrite(fd, string, offset)

--- a/test/test_io_extra.rb
+++ b/test/test_io_extra.rb
@@ -7,7 +7,7 @@
 require 'test-unit'
 require 'rbconfig'
 require 'io/nonblock'
-require 'io/extra'
+require 'io-extra'
 
 class TC_IO_Extra < Test::Unit::TestCase
   def setup
@@ -17,14 +17,8 @@ class TC_IO_Extra < Test::Unit::TestCase
   end
 
   def test_version
-    assert_equal('1.3.0', IO::EXTRA_VERSION)
+    assert_equal('1.4.0', IO::EXTRA_VERSION)
     assert_true(IO::EXTRA_VERSION.frozen?)
-  end
-
-  def test_direct_constant
-    omit_unless(RbConfig::CONFIG['host_os'] =~ /linux/i, 'Linux-only')
-    assert_equal(040000, IO::DIRECT)
-    assert_equal(040000, File::DIRECT)
   end
 
   def test_open_direct
@@ -75,7 +69,7 @@ class TC_IO_Extra < Test::Unit::TestCase
     @fh.close rescue nil
     @fh = File.open(@file)
     assert_respond_to(IO, :pread)
-    assert_equal("quick", IO.pread(@fh.fileno, 5, 4))
+    assert_equal("quick", IO.pread(@fh, 5, 4))
   end
 
   def test_pread_binary
@@ -86,34 +80,26 @@ class TC_IO_Extra < Test::Unit::TestCase
     assert_nothing_raised { @fh.syswrite("FOO\0HELLO") }
     @fh.close rescue nil
     @fh = File.open(@file)
-    assert_equal("O\0H", IO.pread(@fh.fileno, 3, size + 2))
-  end
-
-  def test_pread_ptr
-    @fh.close rescue nil
-    @fh = File.open(@file)
-    assert_respond_to(IO, :pread_ptr)
-    assert_kind_of(Integer, IO.pread_ptr(@fh.fileno, 5, 4))
+    assert_equal("O\0H", IO.pread(@fh, 3, size + 2))
   end
 
   def test_pread_last
     @fh.close rescue nil
     @fh = File.open(@file)
     size = @fh.stat.size
-    assert_equal("ck\n", IO.pread(@fh.fileno, 5, size - 3))
+    assert_equal("ck\n", IO.pread(@fh, 5, size - 3))
   end
 
   def test_pwrite
     assert_respond_to(IO, :pwrite)
-    assert_nothing_raised{ IO.pwrite(@fh.fileno, "HAL", 0) }
+    assert_nothing_raised{ IO.pwrite(@fh, "HAL", 0) }
   end
 
   def test_writev
     assert_respond_to(IO, :writev)
-    assert_equal(10, IO.writev(@fh.fileno, %w(hello world)))
+    assert_equal(10, IO.writev(@fh, %w[hello world]))
   end
 
-=begin
   def test_writev_retry
     empty = ""
     if empty.respond_to?(:force_encoding)
@@ -147,7 +133,6 @@ class TC_IO_Extra < Test::Unit::TestCase
        end
     end
   end
-=end
 
   def test_ttyname
     assert_respond_to(@fh, :ttyname)


### PR DESCRIPTION
Since Ruby 2.5 added a pread and pwrite instance method, this PR removes the C extension code, and just replaces them with a pure Ruby singleton wrapper around those instance methods. In addition, it removes the `pread_ptr` method, which I don't think was actually being used.

The pread and pwrite singletons also take a file handle (instead of a fileno) as arguments, while the writev method handles either.

A LICENSE file was also added as per the Apache-2.0 requirements.