### PR TITLE
Refactor fdwalk with ensure block

### DIFF
--- a/ext/io/extra.c
+++ b/ext/io/extra.c
@@ -134,7 +134,9 @@ static int close_func(void* lowfd, int fd){
 /* Structure to pass data to fdwalk_body and fdwalk_ensure */
 struct fdwalk_data {
   int lowfd;
-  DIR *dir;  /* Only used when PROC_SELF_FD_DIR is defined */
+#ifdef PROC_SELF_FD_DIR
+  DIR *dir;
+#endif
 };
 
 /* Cleanup function for rb_ensure */

--- a/spec/io_extra_spec.rb
+++ b/spec/io_extra_spec.rb
@@ -70,13 +70,11 @@ describe IO do
 
   context 'fdwalk' do
     example 'fdwalk basic functionality' do
-      skip 'unsupported on OSX' if osx
       expect(IO).to respond_to(:fdwalk)
       expect{ IO.fdwalk(0){} }.not_to raise_error
     end
 
     example 'fdwalk_honors_lowfd' do
-      skip 'unsupported on OSX' if osx
       IO.fdwalk(1){ |f| expect(f.fileno >= 1).to be(true) }
     end
   end


### PR DESCRIPTION
Heavily refactored by Claude to use an ensure block.

This also means it will work on Macs.